### PR TITLE
consistently spell 'canceled' with one L

### DIFF
--- a/bubblewrap.go
+++ b/bubblewrap.go
@@ -1,5 +1,5 @@
 package bubblewrap
 
-// CancelError is returned when the user indicates they want the input to be cancelled,
+// CancelError is returned when the user indicates they want the input to be canceled,
 // by using the escape or Control C inputs.
 type CancelError error

--- a/choose.go
+++ b/choose.go
@@ -190,7 +190,7 @@ func (c *chooser) choose() ([]string, error) {
 		return []string{}, err
 	}
 	if c.aborted {
-		return []string{}, CancelError(fmt.Errorf("user cancelled operation"))
+		return []string{}, CancelError(fmt.Errorf("user canceled operation"))
 	}
 	return c.selected(), nil
 }

--- a/choose_test.go
+++ b/choose_test.go
@@ -36,7 +36,7 @@ func TestChooseUpdate(t *testing.T) {
 			cmds:     []tea.Cmd{nil, nil, nil, nil, tea.Quit},
 		},
 		{
-			name:     "cancelled with ctrl+c",
+			name:     "canceled with ctrl+c",
 			choices:  []string{"one", "two", "three"},
 			expected: []string{},
 			inputs:   []tea.KeyMsg{{Type: tea.KeyCtrlC}},

--- a/examples/Choose/main.go
+++ b/examples/Choose/main.go
@@ -21,7 +21,7 @@ func main() {
 	if err != nil {
 		switch err.(type) {
 		case bubblewrap.CancelError:
-			log.Fatal("[warn] user cancelled")
+			log.Fatal("[warn] user canceled")
 		default:
 			log.Fatal(fmt.Errorf("error getting choice: %w", err))
 		}


### PR DESCRIPTION
👋 Hi @yardbirdsax !

While both "cancelled" and "canceled" are acceptable spellings, "canceled" is typically more common in American English. This makes bubblewrap consistently use the American spelling.